### PR TITLE
 Add support for customizable shortcut length

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,12 +14,19 @@
   "categories": [
     "Other"
   ],
-  "activationEvents": ["onStartupFinished"],
+  "activationEvents": [
+    "onStartupFinished"
+  ],
   "main": "./out/extension.js",
   "contributes": {
     "configuration": {
       "title": "FastTyping",
       "properties": {
+        "fasttyping.maxShortcutLength": {
+          "type": "number",
+          "default": 10,
+          "description": "Max length of characters to detect a shortcut."
+        },
         "fasttyping.shortcuts": {
           "title": "Shortcuts",
           "type": "object",


### PR DESCRIPTION
This PR introduces a new configuration parameter to specify the maximum length of shortcuts (fasttyping.maxShortcutLength).

It also enables support for shortcuts longer than 2 characters, allowing more flexible and powerful expansions (e.g. &&& → "test").

Let me know if you'd like this behavior to be limited by language or scope.